### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "NBBottomSheet",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(
+            name: "NBBottomSheet",
+            targets: ["NBBottomSheet"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "NBBottomSheet",
+            path: "NBBottomSheet/NBBottomSheet/Sources"
+        )
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.